### PR TITLE
Fixed Stringify Issue.

### DIFF
--- a/functions/crud.js
+++ b/functions/crud.js
@@ -3,36 +3,28 @@
  * @param {Object} schema - an object containing property names as keys; values are the constructor for the type of data contained at this key
  * 
  * TODO: all of our values will currently get stringified when they are passed into .property(); we need to determine if boolean values are accepted/passed as strings
+ * [ x ] Eric Stallings, 8/23
  * 
  * TODO: validate inputs to Model and create (for example, if a property is passed into create that IS NOT a property on the model, we shouldn't add that property to our object)
+ * [ x ] Eric Stallings, 8/23
  */
-
-function Model(label, schema = {}) {
+function VertexModel(label, schema = {}) {
   this.label = label;
   Object.entries(schema).forEach((keyValuePair) => {
     this[keyValuePair[0]] = keyValuePair[1];
   });
 }
 
-Model.prototype.create = function create(props) {
+VertexModel.prototype.create = function create(props) {
   let gremlinString = `g.addV('${this.label}')`;
-  
+  const created = Object.assign({}, props);
   Object.keys(props).forEach(prop => {
-    this[prop] = this[prop](props[prop]);
+    created[prop] = created[prop][props[prop]];
+    if (typeof props[prop] !== 'string'){
+    gremlinString += `.property('${prop}', ${props[prop]})`;
+    } else {
     gremlinString += `.property('${prop}', '${props[prop]}')`;
+    }
   })
-  console.log(gremlinString);
   return gremlinString;
 }
-
-const User = new Model('User', {name: String, age: Number});
-
-console.log(JSON.stringify(User));
-
-const sam = User.create(
-  {
-    name: 'Sam', 
-    age: 30,
-  });
-
-console.log(sam);


### PR DESCRIPTION
August 23
-Fixed issue where all values being passed into a new instance of a Vertex were stringified, regardless of TYPE. 

To create a new Vertex Model: 
1. Declare a constant variable (it should be a LABEL, i.e. "User", "Company", etc.).
2. Set the value equal to a new VertexModel. 
3. A new VertexModel takes in two arguments, a label (as a STRING), and an object.
4. This object should have key/value pairs in the format: property: dataType

This new vertex model can then be used to create instances of that model type. 

**Example:**
const User = new VertexModel('User', {name: String, age: Number});
const sam = User.create({name: 'Sam', age: 30});


